### PR TITLE
mupdf 1.28.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,31 +1,57 @@
 @echo on
+setlocal EnableDelayedExpansion
 
-set PKG_CONFIG_PATH="%LIBRARY_LIB%\pkgconfig"
-set PYTHONPATH="%PREFIX%\Lib\site-packages"
-set BUILD_DIR=build-release-x64
+set "SLN_PLAT=%CMAKE_GENERATOR_PLATFORM%"
+set "SLN_DIR=platform\win32"
+set "SLN_FILE=mupdf.sln"
+set "CONFIG=Release"
 
-copy %RECIPE_DIR%\CMakeLists.txt .
+:: Work around Python 3.8+ DLL search restrictions for libclang.
+:: conda libclang installs a versioned DLL (libclang-*.dll) in %LIBRARY_BIN%;
+:: clang.cindex expects "libclang.dll", and Python 3.8+ won't search PATH for it.
+for %%f in ("%LIBRARY_BIN%\libclang-*.dll") do (
+    copy "%%f" "%LIBRARY_BIN%\libclang.dll"
+)
+set "PTH_FILE=%PREFIX%\Lib\site-packages\_conda_dll_search.pth"
+> "%PTH_FILE%" echo import os; os.add_dll_directory(os.environ['LIBRARY_BIN']) if hasattr(os, 'add_dll_directory') and os.environ.get('LIBRARY_BIN') and os.path.isdir(os.environ['LIBRARY_BIN']) else None
+
+:: Build Python bindings via pip. setup.py runs scripts/mupdfwrap.py
+:: (generate C++, build mupdfcpp64.dll via devenv, SWIG, build _mupdf.pyd).
+set MUPDF_SETUP_USE_CLANG_PYTHON=1
+set MUPDF_SETUP_USE_SWIG=1
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
 if errorlevel 1 exit 1
 
-make generate
+:: Clean up build-time artifacts so they don't get packaged.
+del "%PTH_FILE%" 2>nul
+del "%LIBRARY_BIN%\libclang.dll" 2>nul
+
+:: Build mutool via MSBuild; reuses libmupdf.lib already built above.
+msbuild %SLN_DIR%\%SLN_FILE% ^
+    /p:Configuration=%CONFIG% ^
+    /p:Platform=%SLN_PLAT% ^
+    /t:mutool ^
+    /verbosity:normal
 if errorlevel 1 exit 1
 
-@REM Configure using the CMakeFiles
-cmake -B %BUILD_DIR% -G Ninja -S %SRC_DIR% ^
-      -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
-      -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
-      -DCMAKE_BUILD_TYPE:STRING=Release
+:: Install mutool, headers, and libraries
+cmake -E make_directory %LIBRARY_BIN%
+if errorlevel 1 exit 1
+cmake -E copy %SRC_DIR%\%SLN_DIR%\%SLN_PLAT%\%CONFIG%\mutool.exe %LIBRARY_BIN%\
 if errorlevel 1 exit 1
 
-@REM Build!
-cmake --build %BUILD_DIR% --config Release
+cmake -E make_directory %LIBRARY_INC%
+if errorlevel 1 exit 1
+cmake -E copy_directory %SRC_DIR%\include %LIBRARY_INC%
+if errorlevel 1 exit 1
+cmake -E copy_directory %SRC_DIR%\platform\c++\include %LIBRARY_INC%
 if errorlevel 1 exit 1
 
-@REM Produce C++ bindings, as it is done via python script rather then build system
-%CONDA_PYTHON_EXE% scripts\mupdfwrap.py -d %BUILD_DIR% -b all -o windows
+cmake -E make_directory %LIBRARY_LIB%
 if errorlevel 1 exit 1
-
-@REM Install!
-cmake --install %BUILD_DIR% --config Release
-if errorlevel 1 exit 1
-
+for %%f in (%SRC_DIR%\%SLN_DIR%\%SLN_PLAT%\%CONFIG%\*.lib) do (
+    copy "%%f" "%LIBRARY_LIB%\"
+)
+for %%f in (%SRC_DIR%\%SLN_DIR%\%SLN_PLAT%\%CONFIG%\*.dll) do (
+    copy "%%f" "%LIBRARY_BIN%\"
+)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,14 +20,25 @@ export USE_SYSTEM_MUJS=yes
 export USE_SYSTEM_JPEGXR=yes
 export VENV_FLAG=""
 
-# build and install
-# Clang chokes on large font lexing so reduce the number of jobs
+# Point the mupdf Python binding build to the HOST Python (not BUILD_PREFIX Python).
+# Without this, pipcl.PythonFlags uses sys.executable (BUILD_PREFIX) to find
+# python-config, causing an ABI mismatch with the target Python.
+export PIPCL_PYTHON_CONFIG="${PREFIX}/bin/python3-config"
+
+# USE_ARGUMENT_FILE=no: conda's ar doesn't support @file response files
+# Build 'all' and 'python' separately to avoid a race: 'python' depends on
+# 'shared-release' which triggers a recursive make that races with the parent
+# make's link step for mutool (undefined murun_main).
+# Clang chokes on large font lexing so reduce the number of jobs on osx.
 if [[ "$target_platform" == osx* ]]; then
-  make prefix="${PREFIX}" pydir="${SP_DIR}" shared=yes -j1
+  JOBS=1
 else
-  make prefix="${PREFIX}" pydir="${SP_DIR}" shared=yes -j${CPU_COUNT}
+  JOBS=${CPU_COUNT}
 fi
-make prefix="${PREFIX}" pydir="${SP_DIR}" shared=yes install install-shared-python
+
+make prefix="${PREFIX}" pydir="${SP_DIR}" shared=yes USE_ARGUMENT_FILE=no -j${JOBS} all
+make prefix="${PREFIX}" pydir="${SP_DIR}" shared=yes USE_ARGUMENT_FILE=no -j${JOBS} python
+make prefix="${PREFIX}" pydir="${SP_DIR}" shared=yes USE_ARGUMENT_FILE=no install install-shared-python
 
 if [[ "$target_platform" == osx* ]]; then
     install_name_tool -id @rpath/libmupdfcpp.dylib $PREFIX/lib/libmupdfcpp.dylib

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler:    # [win]
-  - clang      # [win]
-cxx_compiler:  # [win]
-  - clang      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,9 @@ source:
       - patches/MakefileOSX.patch         # [osx]
       # libmupdfcpp.dylib naming in Python wrap scripts
       - patches/OSXSharedCreation.patch   # [osx]
+      # PBP VS BuildTools has MSBuild but not devenv.com
+      - patches/wdev-buildtools-no-devenv.patch  # [win]
+      - patches/wrap-msbuild-fallback.patch      # [win]
 
 build:
   number: 0
@@ -29,13 +32,14 @@ requirements:
     - python
     - pkg-config
     # pyclang needed for library generation through Python scripts
-    - python-clang
+    # 22.x fails to find fz_pixmap.refs when wrapping 1.28 headers (cf: python-clang <22)
+    - python-clang <22
     - swig
   host:
     - python
     - pip              # [win]
     - setuptools       # [win]
-    - python-clang     # [win]
+    - python-clang <22  # [win]
     - mujs 1.3.8
     - libgumbo 1.0.0
     - jbig2dec 0.20

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ source:
       # PBP VS BuildTools has MSBuild but not devenv.com
       - patches/wdev-buildtools-no-devenv.patch  # [win]
       - patches/wrap-msbuild-fallback.patch      # [win]
+      # bin2coff was Win32-only; MSBuild x64 needs Release|x64 (MSB8013)
+      - patches/bin2coff-release-x64.patch       # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mupdf" %}
-{% set version = "1.27.0" %}
+{% set version = "1.28.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,27 +7,24 @@ package:
 
 source:
   - url: https://www.mupdf.com/downloads/archive/{{ name }}-{{ version }}-source.tar.gz
-    sha256: ae2442416de499182d37a526c6fa2bacc7a3bed5a888d113ca04844484dfe7c6
+    sha256: 21c7f064903154f1c3a7458bee81f130fc36f9b5147ea13328f9980e02d2dea2
     patches:
-      # OSX has libfreetype.a, not libfreetype2.a
+      # OSX has libfreetype.a, not libfreetype2.a; drop xcrun wrappers
       - patches/Makerules.patch           # [osx]
+      # Shared-lib link/install + _mupdf.so extension name on Darwin
       - patches/MakefileOSX.patch         # [osx]
+      # libmupdfcpp.dylib naming in Python wrap scripts
       - patches/OSXSharedCreation.patch   # [osx]
 
 build:
-  number: 2
-  skip: true  # [win]
+  number: 0
 
 requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - msys2-sed        # [win]
-    - msys2-make       # [win]
-    - msys2-coreutils  # [win]
     - cmake            # [win]
-    - ninja-base       # [win]
     - make             # [unix]
     - python
     - pkg-config
@@ -36,12 +33,14 @@ requirements:
     - swig
   host:
     - python
-    - python-clang
-    - mujs
-    - libgumbo
-    - jbig2dec
+    - pip              # [win]
+    - setuptools       # [win]
+    - python-clang     # [win]
+    - mujs 1.3.8
+    - libgumbo 1.0.0
+    - jbig2dec 0.20
     - brotli {{ brotli }}
-    - xorg-libxfixes  # [unix]
+    - xorg-libxfixes 6.0.1  # [unix]
     - libglu {{ libglu }}  # [linux]
     - mesalib {{ mesalib }}  # [linux]
     - freetype {{ freetype }}
@@ -62,13 +61,16 @@ requirements:
     - curl
 
 test:
+  imports:
+    - mupdf
   commands:
     - test -f $PREFIX/bin/mutool  # [unix]
     - test -f $PREFIX/lib/libmupdf${SHLIB_EXT}  # [unix]
+    - mutool -v
     - if not exist %LIBRARY_BIN%\\mutool.exe exit 1  # [win]
 
 about:
-  home: https://www.mupdf.com
+  home: https://mupdf.com
   license: AGPL-3.0-only
   license_family: GPL
   license_file: COPYING
@@ -78,7 +80,7 @@ about:
     It renders text with metrics and spacing accurate to within fractions of
     a pixel for the highest fidelity in reproducing the look of a printed page
     on screen.
-  doc_url: https://www.mupdf.com/docs
+  doc_url: https://mupdf.com/docs
   dev_url: https://github.com/ArtifexSoftware/mupdf
 
 extra:

--- a/recipe/patches/MakefileOSX.patch
+++ b/recipe/patches/MakefileOSX.patch
@@ -63,13 +63,13 @@ index b690833..633b04d 100644
 +$(PKCS7_LIB) : $(PKCS7_OBJ)
 +
 +$(MUPDF_LIB) : $(MUPDF_OBJ) $(THIRD_LIB) $(THREAD_LIB)
-+	$(LINK_CMD) -shared -Wl,-install_name -Wl,libmupdf.$(SO) -undefined dynamic_lookup $(THIRD_LIBS)
++	$(LINK_CMD) -shared -Wl,-install_name -Wl,libmupdf.$(SO) -undefined dynamic_lookup $(THIRD_LIBS) $(LIBCRYPTO_LIBS)
 +$(THIRD_LIB) : $(THIRD_OBJ)
 +	$(LINK_CMD) -shared -Wl,-install_name -Wl,libmupdf-third.$(SO) -undefined dynamic_lookup
 +$(THREAD_LIB) : $(THREAD_OBJ)
 +	$(LINK_CMD) -shared -Wl,-install_name -Wl,libmupdf-threads.$(SO) -undefined dynamic_lookup -lpthread
 +$(PKCS7_LIB) : $(PKCS7_OBJ)
-+	$(LINK_CMD) -v -shared -Wl,-install_name -Wl,libmupdf-pkcs7.$(SO) -undefined dynamic_lookup
++	$(LINK_CMD) -v -shared -Wl,-install_name -Wl,libmupdf-pkcs7.$(SO) -undefined dynamic_lookup $(LIBCRYPTO_LIBS)
 +
 +LIBS_TO_INSTALL_IN_LIB := $(MUPDF_LIB) $(THIRD_LIB) $(THREAD_LIB) $(PKCS7_LIB)
 

--- a/recipe/patches/bin2coff-release-x64.patch
+++ b/recipe/patches/bin2coff-release-x64.patch
@@ -1,0 +1,73 @@
+--- a/platform/win32/bin2coff.vcxproj
++++ b/platform/win32/bin2coff.vcxproj
+@@ -5,6 +5,10 @@
+       <Configuration>Release</Configuration>
+       <Platform>Win32</Platform>
+     </ProjectConfiguration>
++    <ProjectConfiguration Include="Release|x64">
++      <Configuration>Release</Configuration>
++      <Platform>x64</Platform>
++    </ProjectConfiguration>
+   </ItemGroup>
+   <PropertyGroup Label="Globals">
+     <ProjectGuid>{BFE316B3-BD90-433A-A20D-C73975F1CAA7}</ProjectGuid>
+@@ -19,12 +23,21 @@
+     <CharacterSet>Unicode</CharacterSet>
+     <WholeProgramOptimization>true</WholeProgramOptimization>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
++    <ConfigurationType>Application</ConfigurationType>
++    <PlatformToolset>v142</PlatformToolset>
++    <CharacterSet>Unicode</CharacterSet>
++    <WholeProgramOptimization>true</WholeProgramOptimization>
++  </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ImportGroup Label="ExtensionSettings">
+   </ImportGroup>
+   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+   </ImportGroup>
++  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
++    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
++  </ImportGroup>
+   <PropertyGroup Label="UserMacros" />
+   <PropertyGroup>
+     <_ProjectFileVersion>15.0.28307.799</_ProjectFileVersion>
+@@ -34,6 +47,11 @@
+     <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+     <LinkIncremental>false</LinkIncremental>
+   </PropertyGroup>
++  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
++    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
++    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
++    <LinkIncremental>false</LinkIncremental>
++  </PropertyGroup>
+   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+     <ClCompile>
+       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+@@ -53,6 +71,25 @@
+       <TargetMachine>MachineX86</TargetMachine>
+     </Link>
+   </ItemDefinitionGroup>
++  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
++    <ClCompile>
++      <PreprocessorDefinitions>WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
++      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
++      <PrecompiledHeader />
++      <WarningLevel>Level4</WarningLevel>
++      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
++      <DisableSpecificWarnings>4100;4200</DisableSpecificWarnings>
++      <MinimalRebuild>
++      </MinimalRebuild>
++    </ClCompile>
++    <Link>
++      <GenerateDebugInformation>true</GenerateDebugInformation>
++      <SubSystem>Console</SubSystem>
++      <OptimizeReferences>true</OptimizeReferences>
++      <EnableCOMDATFolding>true</EnableCOMDATFolding>
++      <TargetMachine>MachineX64</TargetMachine>
++    </Link>
++  </ItemDefinitionGroup>
+   <ItemGroup>
+     <ClCompile Include="..\..\scripts\bin2coff.c" />
+   </ItemGroup>

--- a/recipe/patches/wdev-buildtools-no-devenv.patch
+++ b/recipe/patches/wdev-buildtools-no-devenv.patch
@@ -1,0 +1,16 @@
+--- a/scripts/wdev.py
++++ b/scripts/wdev.py
+@@ -78,10 +78,11 @@
+             directories.sort()
+             directory = directories[-1]
+ 
+-            # Find `devenv`.
++            # Find `devenv` (absent on VS BuildTools — CI often has MSBuild only).
+             #
+             devenv = f'{directory}\\Common7\\IDE\\devenv.com'
+-            assert os.path.isfile( devenv), f'Does not exist: {devenv}'
++            if not os.path.isfile(devenv):
++                devenv = None
+ 
+             # Extract `year` and `grade` from `directory`.
+             #

--- a/recipe/patches/wrap-msbuild-fallback.patch
+++ b/recipe/patches/wrap-msbuild-fallback.patch
@@ -1,6 +1,6 @@
 --- a/scripts/wrap/__main__.py
 +++ b/scripts/wrap/__main__.py
-@@ -1648,20 +1648,36 @@
+@@ -1648,20 +1648,37 @@
                      # no mupdf.dll.
                      #
                      win32_infix = _windows_vs_upgrade( vs_upgrade, build_dirs, devenv)
@@ -31,17 +31,18 @@
 +                            command2 = f'{command} /Project {project}'
 +                            jlib.system(command2, verbose=1, out='log')
 +                    else:
-+                        # PBP/CI VS BuildTools ships MSBuild but not devenv.com.
++                        # PBP/CI VS BuildTools has MSBuild but not devenv.com.
++                        # Build .vcxproj files directly — /t:ProjectName on a .sln
++                        # is not a valid MSBuild target (MSB4057).
 +                        assert windows_vs and windows_vs.msbuild, 'No devenv.com or MSBuild.exe found'
 +                        jlib.log(f'Building mupdfcpp.dll by running msbuild ({windows_vs.msbuild}) ...')
 +                        for project in projects:
 +                            command2 = (
 +                                    f'cd {build_dirs.dir_mupdf}&&'
 +                                    f'"{windows_vs.msbuild}"'
-+                                    f' platform/{win32_infix}/mupdf.sln'
++                                    f' platform/{win32_infix}/{project}.vcxproj'
 +                                    f' /p:Configuration={windows_build_type2}'
 +                                    f' /p:Platform={build_dirs.cpu.windows_config}'
-+                                    f' /t:{project}'
 +                                    f' /verbosity:minimal'
 +                                    )
 +                            jlib.system(command2, verbose=1, out='log')

--- a/recipe/patches/wrap-msbuild-fallback.patch
+++ b/recipe/patches/wrap-msbuild-fallback.patch
@@ -1,0 +1,50 @@
+--- a/scripts/wrap/__main__.py
++++ b/scripts/wrap/__main__.py
+@@ -1648,20 +1648,36 @@
+                     # no mupdf.dll.
+                     #
+                     win32_infix = _windows_vs_upgrade( vs_upgrade, build_dirs, devenv)
+-                    jlib.log(f'Building mupdfcpp.dll by running devenv ...')
+-                    build = f'{windows_build_type2}|{build_dirs.cpu.windows_config}'
+-                    command = (
+-                            f'cd {build_dirs.dir_mupdf}&&'
+-                            f'"{devenv}"'
+-                            f' platform/{win32_infix}/mupdf.sln'
+-                            f' /Build "{build}"'
+-                            )
+                     projects = ['mupdfcpp', 'libmuthreads']
+                     if m_target:
+                         projects += m_target.split(',')
+-                    for project in projects:
+-                        command2 = f'{command} /Project {project}'
+-                        jlib.system(command2, verbose=1, out='log')
++                    if devenv:
++                        jlib.log(f'Building mupdfcpp.dll by running devenv ...')
++                        build = f'{windows_build_type2}|{build_dirs.cpu.windows_config}'
++                        command = (
++                                f'cd {build_dirs.dir_mupdf}&&'
++                                f'"{devenv}"'
++                                f' platform/{win32_infix}/mupdf.sln'
++                                f' /Build "{build}"'
++                                )
++                        for project in projects:
++                            command2 = f'{command} /Project {project}'
++                            jlib.system(command2, verbose=1, out='log')
++                    else:
++                        # PBP/CI VS BuildTools ships MSBuild but not devenv.com.
++                        assert windows_vs and windows_vs.msbuild, 'No devenv.com or MSBuild.exe found'
++                        jlib.log(f'Building mupdfcpp.dll by running msbuild ({windows_vs.msbuild}) ...')
++                        for project in projects:
++                            command2 = (
++                                    f'cd {build_dirs.dir_mupdf}&&'
++                                    f'"{windows_vs.msbuild}"'
++                                    f' platform/{win32_infix}/mupdf.sln'
++                                    f' /p:Configuration={windows_build_type2}'
++                                    f' /p:Platform={build_dirs.cpu.windows_config}'
++                                    f' /t:{project}'
++                                    f' /verbosity:minimal'
++                                    )
++                            jlib.system(command2, verbose=1, out='log')
+ 
+                     for suffix in ('.dll', '.pdb'):
+                         jlib.fs_copy(


### PR DESCRIPTION
## mupdf 1.28.0

**Destination channel:** defaults

### Links
- [PKG-16384](https://anaconda.atlassian.net/browse/PKG-16384)
- [MuPDF downloads](https://mupdf.com/releases/index.html)
- [CVE-2026-3308](https://nvd.nist.gov/vuln/detail/CVE-2026-3308)

### Explanation of changes:
- Updated mupdf from 1.27.0 to 1.28.0 for CVE-2026-3308
- Enabled win-64 (was skipped): MSBuild + pip bindings install instead of clang/CMake, drop win clang CBC override so vs2022 is used
- Windows BuildTools fixes: allow missing devenv.com, MSBuild the `.vcxproj` files directly, and add `Release|x64` to `bin2coff.vcxproj` (MSB8013)
- Pin `python-clang <22` so wrapping still sees `fz_pixmap.refs` under clang 22
- OSX: link `LIBCRYPTO_LIBS` so `mutool` resolves PKCS12 under the flat namespace
- Unix `build.sh`: split `all`/`python`, set `PIPCL_PYTHON_CONFIG` and `USE_ARGUMENT_FILE=no`
- Exact host pins for mujs, libgumbo, jbig2dec, and xorg-libxfixes; point home/doc_url at apex `mupdf.com` (no www redirect)
- Tests: `import mupdf` and `mutool -v`, plus existing path checks

[PKG-16384]: https://anaconda.atlassian.net/browse/PKG-16384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ